### PR TITLE
Setup message channel

### DIFF
--- a/force-app/main/default/lwc/mainContainer/mainContainer.js
+++ b/force-app/main/default/lwc/mainContainer/mainContainer.js
@@ -1,7 +1,43 @@
-import { LightningElement } from 'lwc';
-import LOGO_URL from '@salesforce/resourceUrl/Logo'
+import { LightningElement, wire } from 'lwc';
+import { subscribe, MessageContext, APPLICATION_SCOPE } from 'lightning/messageService';
+import MainChannel from '@salesforce/messageChannel/mainChannel__c';
+import LOGO_URL from '@salesforce/resourceUrl/Logo';
+
 
 export default class MainContainer extends LightningElement {
-    homePage = true;
+    updatePageVar;
+    homePage;
+
+    subscription = null;
     logoUrl = LOGO_URL;
+
+    @wire(MessageContext)
+    mContext;
+
+    updatePageMethod(updater){
+        // reset all page booleans to false
+        this.homePage = false;
+
+        //set new page boolean to true
+        switch (updater){
+            default:
+                this.homePage = true;
+        }
+    }
+
+    subscribeToMessageChannel(){
+        if(!this.subscription){
+            this.subscription = subscribe(
+                this.mContext,
+                MainChannel,
+                (payload) => {this.updatePageVar = payload.updatePage},
+                { scope : APPLICATION_SCOPE}
+            );    
+        }
+    }
+
+    connectedCallback(){
+        this.subscribeToMessageChannel();
+        this.updatePageMethod();
+    }
 }

--- a/force-app/main/default/messageChannels/mainChannel.messageChannel-meta.xml
+++ b/force-app/main/default/messageChannels/mainChannel.messageChannel-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningMessageChannel xmlns="http://soap.sforce.com/2006/04/metadata">
+    <masterLabel>testMessageChannel</masterLabel>
+    <isExposed>true</isExposed>
+    <lightningMessageFields>
+        <fieldName>updatePage</fieldName>
+    </lightningMessageFields>
+</LightningMessageChannel>


### PR DESCRIPTION
In this commit I setup the main container to subscribe to a new message channel (mainChannel). The message channel has a field named "updatePage" which can be published to. This updatePage field should be published to going forward in order to update the main content on the main container.

For example, if you would like to "link" to the location page, publish a string to the updatePage field in the mainChannel, and this is what we will use to conditionally render the content on the main container.  